### PR TITLE
add settings to avoid overbooking of cluster nodes

### DIFF
--- a/config/submit.sh.jinja2
+++ b/config/submit.sh.jinja2
@@ -10,6 +10,7 @@
 #SBATCH --mail-user={{s.user}}@pik-potsdam.de
 #SBATCH --ntasks=1
 #SBATCH --array=0-{{s.njobarray-1}}
+#SBATCH --cpus-per-task=1
 #SBATCH --time=00-23:50:00
 
 module purge
@@ -29,6 +30,6 @@ mkdir -p $cdir
 export THEANO_FLAGS=base_compiledir=$cdir
 # export I_MPI_DEBUG=5
 
-srun -n $SLURM_NTASKS {{s.conda_path}}/bin/python run_bayes.py
+srun -n $SLURM_NTASKS {{s.conda_path}}/bin/python -u run_bayes.py
 
 echo "Finished run."

--- a/run_bayes.py
+++ b/run_bayes.py
@@ -11,6 +11,7 @@ try:
     submitted = os.environ["SUBMITTED"] == "1"
     task_id = int(os.environ["SLURM_ARRAY_TASK_ID"])
     njobarray = int(os.environ["SLURM_ARRAY_TASK_COUNT"])
+    s.ncores_per_job = 1
 except KeyError:
     submitted = False
     njobarray = 1


### PR DESCRIPTION
A small but important one, after talking to Ciaron:

Enfore only one CPU for each job through settings,
and as well in the the slurm script.
python -u provides unbuffered output to .out file.