### PR TITLE
Allow nocycle

### DIFF
--- a/icounter/estimator.py
+++ b/icounter/estimator.py
@@ -41,11 +41,12 @@ class estimator(object):
         self.qm_ref_period = cfg.qm_ref_period
         self.save_trace = cfg.save_trace
         self.report_mu_sigma = cfg.report_mu_sigma
+        self.mu_model = cfg.mu_model
         self.sigma_model = cfg.sigma_model
         self.inference = cfg.inference
 
         try:
-            self.statmodel = model_for_var[self.variable](self.modes, self.sigma_model)
+            self.statmodel = model_for_var[self.variable](self.modes, self.mu_model, self.sigma_model)
         except KeyError as error:
             print(
                 "No statistical model for this variable. Probably treated as part of other variables."

--- a/icounter/estimator.py
+++ b/icounter/estimator.py
@@ -140,9 +140,12 @@ class estimator(object):
 
             with self.model:
                 pm.set_data({"xf0": xf0})
-                pm.set_data({"xf1": xf1})
                 pm.set_data({"xf2": xf2})
                 pm.set_data({"gmt": df["gmt_scaled"].values})
+
+                if self.mu_model == "full":
+                    pm.set_data({"xf1": xf1})
+
                 if self.sigma_model == "full":
                     pm.set_data({"xf3": xf3})
 

--- a/icounter/logistic.py
+++ b/icounter/logistic.py
@@ -46,11 +46,16 @@ def longterm_yearlycycle(model, name, gmt, xfa, ic_mu=0.0, ic_sigma=1.0):
     return pm.Deterministic(name, param)
 
 
-# def longterm_yearlycycle(gmt, p_intercept, p_slope, p_yearly, xf_yearly):
+def longterm(model, name, gmt, ic_mu=0.0, ic_sigma=1.0):
 
-#     return p_intercept / (
-#         1 + tt.exp(-1 * (p_slope * gmt + det_dot(xf_yearly, p_yearly)))
-#     )
+    with model:
+
+        intercept = pm.Lognormal(name + "_intercept", mu=ic_mu, sigma=ic_sigma)
+
+        slope = pm.Normal(name + "_slope", mu=0, sigma=1)
+        param = intercept / (1 + tt.exp(-1 * (slope * gmt)))
+
+    return pm.Deterministic(name, param)
 
 
 def yearlycycle(model, name, xfa, ic_mu=0.0, ic_sigma=1.0):
@@ -64,8 +69,3 @@ def yearlycycle(model, name, xfa, ic_mu=0.0, ic_sigma=1.0):
         param = intercept / (1 + tt.exp(-1 * det_dot(xfa, yearly)))
 
     return pm.Deterministic(name, param)
-
-
-# def yearlycycle(p_intercept, p_yearly, xf_yearly):
-
-#     return p_intercept / (1 + tt.exp(-1 * det_dot(xf_yearly, p_yearly)))

--- a/icounter/models.py
+++ b/icounter/models.py
@@ -92,6 +92,9 @@ class Gamma(object):
             elif self.mu_model == "longterm_yearlycycle":
                 mu = l.longterm_yearlycycle(model, "mu", gmt, xf0)
 
+            elif self.mu_model == "longterm":
+                mu = l.longterm(model, "mu", gmt)
+
             else:
                 raise NotImplemented
 
@@ -106,6 +109,9 @@ class Gamma(object):
 
             elif self.sigma_model == "longterm_yearlycycle":
                 sigma = l.longterm_yearlycycle(model, "sigma", gmt, xf2)
+
+            elif self.sigma_model == "longterm":
+                sigma = l.longterm(model, "sigma", gmt)
 
             else:
                 raise NotImplemented

--- a/icounter/models.py
+++ b/icounter/models.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pymc3 as pm
 from scipy import stats
-
-# import theano.tensor as tt
 import pandas as pd
 import icounter.logistic as l
 
@@ -66,9 +64,10 @@ class Gamma(object):
     """ Influence of GMT is modelled through the parameters of the Gamma
     distribution. Example: precipitation """
 
-    def __init__(self, modes, sigma_model):
+    def __init__(self, modes, mu_model, sigma_model):
 
         self.modes = modes
+        self.mu_model = mu_model
         self.sigma_model = sigma_model
 
         print("Using Gamma distribution model. Fourier modes:", modes)
@@ -81,10 +80,22 @@ class Gamma(object):
 
             gmt = pm.Data("gmt", df_valid["gmt_scaled"].values)
             xf0 = pm.Data("xf0", df_valid.filter(like="mode_0_").values)
-            xf1 = pm.Data("xf1", df_valid.filter(like="mode_1_").values)
-            xf2 = pm.Data("xf2", df_valid.filter(like="mode_2_").values)
+            # mu = l.full(model, "mu", gmt, xf0, xf1)
 
-            mu = l.full(model, "mu", gmt, xf0, xf1)
+            if self.mu_model == "full":
+                xf1 = pm.Data("xf1", df_valid.filter(like="mode_1_").values)
+                mu = l.full(model, "mu", gmt, xf0, xf1)
+
+            elif self.mu_model == "yearlycycle":
+                mu = l.yearlycycle(model, "mu", xf0)
+
+            elif self.mu_model == "longterm_yearlycycle":
+                mu = l.longterm_yearlycycle(model, "mu", gmt, xf0)
+
+            else:
+                raise NotImplemented
+
+            xf2 = pm.Data("xf2", df_valid.filter(like="mode_2_").values)
 
             if self.sigma_model == "full":
                 xf3 = pm.Data("xf3", df_valid.filter(like="mode_3_").values)

--- a/settings.py
+++ b/settings.py
@@ -27,14 +27,14 @@ timeout = 60 * 60
 variable = "pr"  # select variable to detrend
 # number of modes for fourier series of model
 modes = [2, 1, 1, 1]
-# out of full, longterm_yearlycycle, yearlycycle
-mu_model = "longterm_yearlycycle"
-sigma_model = "longterm_yearlycycle"
+# out of full, longterm_yearlycycle, yearlycycle, longterm
+mu_model = "longterm"
+sigma_model = "longterm"
 # NUTS or ADVI
 inference = "NUTS"
 
 seed = 0  # for deterministic randomisation
-subset = 5  # only use every subset datapoint for bayes estimation for speedup
+subset = 2  # only use every subset datapoint for bayes estimation for speedup
 # use the estimated variability in qm
 scale_variability = False
 # out of "watch+wfdei", "GSWP3", "GSWP3+ERA5"

--- a/settings.py
+++ b/settings.py
@@ -24,10 +24,11 @@ output_dir = Path(data_dir) / "output" / Path.cwd().name
 # max time in sec for sampler for a single grid cell.
 timeout = 60 * 60
 # tas, tasrange pr, prsn, prsnratio, ps, rlds, wind, hurs
-variable = "tas"  # select variable to detrend
+variable = "pr"  # select variable to detrend
 # number of modes for fourier series of model
 modes = [2, 1, 1, 1]
 # out of full, longterm_yearlycycle, yearlycycle
+mu_model = "longterm_yearlycycle"
 sigma_model = "longterm_yearlycycle"
 # NUTS or ADVI
 inference = "NUTS"


### PR DESCRIPTION
We can now choose a model for mu or for sigma, which only has GMT as predictor, and comes without a yearly cycle. Choose via settings.py.